### PR TITLE
🎨 Fix theme prop functionality - v1.0.8

### DIFF
--- a/.cursor/rules/convex_rules.mdc
+++ b/.cursor/rules/convex_rules.mdc
@@ -7,86 +7,86 @@ globs: **/*.ts,**/*.tsx,**/*.js,**/*.jsx
 ## Function guidelines
 ### New function syntax
 - ALWAYS use the new function syntax for Convex functions. For example:
-      ```typescript
-      import { query } from "./_generated/server";
-      import { v } from "convex/values";
-      export const f = query({
-          args: {},
-          returns: v.null(),
-          handler: async (ctx, args) => {
-          // Function body
-          },
-      });
-      ```
+```typescript
+import { query } from "./_generated/server";
+import { v } from "convex/values";
+export const f = query({
+    args: {},
+    returns: v.null(),
+    handler: async (ctx, args) => {
+    // Function body
+    },
+});
+```
 
 ### Http endpoint syntax
 - HTTP endpoints are defined in `convex/http.ts` and require an `httpAction` decorator. For example:
-      ```typescript
-      import { httpRouter } from "convex/server";
-      import { httpAction } from "./_generated/server";
-      const http = httpRouter();
-      http.route({
-          path: "/echo",
-          method: "POST",
-          handler: httpAction(async (ctx, req) => {
-          const body = await req.bytes();
-          return new Response(body, { status: 200 });
-          }),
-      });
-      ```
+```typescript
+import { httpRouter } from "convex/server";
+import { httpAction } from "./_generated/server";
+const http = httpRouter();
+http.route({
+    path: "/echo",
+    method: "POST",
+    handler: httpAction(async (ctx, req) => {
+    const body = await req.bytes();
+    return new Response(body, { status: 200 });
+    }),
+});
+```
 - HTTP endpoints are always registered at the exact path you specify in the `path` field. For example, if you specify `/api/someRoute`, the endpoint will be registered at `/api/someRoute`.
 
 ### Validators
 - Below is an example of an array validator:
-                            ```typescript
-                            import { mutation } from "./_generated/server";
-                            import { v } from "convex/values";
+```typescript
+import { mutation } from "./_generated/server";
+import { v } from "convex/values";
 
-                            export default mutation({
-                            args: {
-                                simpleArray: v.array(v.union(v.string(), v.number())),
-                            },
-                            handler: async (ctx, args) => {
-                                //...
-                            },
-                            });
-                            ```
+export default mutation({
+args: {
+    simpleArray: v.array(v.union(v.string(), v.number())),
+},
+handler: async (ctx, args) => {
+    //...
+},
+});
+```
 - Below is an example of a schema with validators that codify a discriminated union type:
-                            ```typescript
-                            import { defineSchema, defineTable } from "convex/server";
-                            import { v } from "convex/values";
+```typescript
+import { defineSchema, defineTable } from "convex/server";
+import { v } from "convex/values";
 
-                            export default defineSchema({
-                                results: defineTable(
-                                    v.union(
-                                        v.object({
-                                            kind: v.literal("error"),
-                                            errorMessage: v.string(),
-                                        }),
-                                        v.object({
-                                            kind: v.literal("success"),
-                                            value: v.number(),
-                                        }),
-                                    ),
-                                )
-                            });
-                            ```
+export default defineSchema({
+    results: defineTable(
+        v.union(
+            v.object({
+                kind: v.literal("error"),
+                errorMessage: v.string(),
+            }),
+            v.object({
+                kind: v.literal("success"),
+                value: v.number(),
+            }),
+        ),
+    )
+});
+```
 - Always use the `v.null()` validator when returning a null value. Below is an example query that returns a null value:
-                                  ```typescript
-                                  import { query } from "./_generated/server";
-                                  import { v } from "convex/values";
+```typescript
+import { query } from "./_generated/server";
+import { v } from "convex/values";
 
-                                  export const exampleQuery = query({
-                                    args: {},
-                                    returns: v.null(),
-                                    handler: async (ctx, args) => {
-                                        console.log("This query returns a null value");
-                                        return null;
-                                    },
-                                  });
-                                  ```
+export const exampleQuery = query({
+  args: {},
+  returns: v.null(),
+  handler: async (ctx, args) => {
+      console.log("This query returns a null value");
+      return null;
+  },
+});
+```
 - Here are the valid Convex types along with their respective validators:
- Convex Type  | TS/JS type  |  Example Usage         | Validator for argument validation and schemas  | Notes                                                                                                                                                                                                 |
+Convex Type  | TS/JS type  |  Example Usage         | Validator for argument validation and schemas  | Notes                                                                                                                                                                                                 |
 | ----------- | ------------| -----------------------| -----------------------------------------------| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Id          | string      | `doc._id`              | `v.id(tableName)`                              |                                                                                                                                                                                                       |
 | Null        | null        | `null`                 | `v.null()`                                     | JavaScript's `undefined` is not a valid Convex value. Functions the return `undefined` or do not return will return `null` when called from a client. Use `null` instead.                             |
@@ -114,24 +114,24 @@ globs: **/*.ts,**/*.tsx,**/*.js,**/*.jsx
 - Try to use as few calls from actions to queries and mutations as possible. Queries and mutations are transactions, so splitting logic up into multiple calls introduces the risk of race conditions.
 - All of these calls take in a `FunctionReference`. Do NOT try to pass the callee function directly into one of these calls.
 - When using `ctx.runQuery`, `ctx.runMutation`, or `ctx.runAction` to call a function in the same file, specify a type annotation on the return value to work around TypeScript circularity limitations. For example,
-                            ```
-                            export const f = query({
-                              args: { name: v.string() },
-                              returns: v.string(),
-                              handler: async (ctx, args) => {
-                                return "Hello " + args.name;
-                              },
-                            });
+```
+export const f = query({
+  args: { name: v.string() },
+  returns: v.string(),
+  handler: async (ctx, args) => {
+    return "Hello " + args.name;
+  },
+});
 
-                            export const g = query({
-                              args: {},
-                              returns: v.null(),
-                              handler: async (ctx, args) => {
-                                const result: string = await ctx.runQuery(api.example.f, { name: "Bob" });
-                                return null;
-                              },
-                            });
-                            ```
+export const g = query({
+  args: {},
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const result: string = await ctx.runQuery(api.example.f, { name: "Bob" });
+    return null;
+  },
+});
+```
 
 ### Function references
 - Function references are pointers to registered Convex functions.
@@ -150,24 +150,24 @@ globs: **/*.ts,**/*.tsx,**/*.js,**/*.jsx
 - Paginated queries are queries that return a list of results in incremental pages.
 - You can define pagination using the following syntax:
 
-                            ```ts
-                            import { v } from "convex/values";
-                            import { query, mutation } from "./_generated/server";
-                            import { paginationOptsValidator } from "convex/server";
-                            export const listWithExtraArg = query({
-                                args: { paginationOpts: paginationOptsValidator, author: v.string() },
-                                handler: async (ctx, args) => {
-                                    return await ctx.db
-                                    .query("messages")
-                                    .filter((q) => q.eq(q.field("author"), args.author))
-                                    .order("desc")
-                                    .paginate(args.paginationOpts);
-                                },
-                            });
-                            ```
-                            Note: `paginationOpts` is an object with the following properties:
-                            - `numItems`: the maximum number of documents to return (the validator is `v.number()`)
-                            - `cursor`: the cursor to use to fetch the next page of documents (the validator is `v.union(v.string(), v.null())`)
+```ts
+import { v } from "convex/values";
+import { query, mutation } from "./_generated/server";
+import { paginationOptsValidator } from "convex/server";
+export const listWithExtraArg = query({
+    args: { paginationOpts: paginationOptsValidator, author: v.string() },
+    handler: async (ctx, args) => {
+        return await ctx.db
+        .query("messages")
+        .filter((q) => q.eq(q.field("author"), args.author))
+        .order("desc")
+        .paginate(args.paginationOpts);
+    },
+});
+```
+Note: `paginationOpts` is an object with the following properties:
+- `numItems`: the maximum number of documents to return (the validator is `v.number()`)
+- `cursor`: the cursor to use to fetch the next page of documents (the validator is `v.union(v.string(), v.null())`)
 - A query that ends in `.paginate()` returns an object that has the following properties:
                             - page (contains an array of documents that you fetches)
                             - isDone (a boolean that represents whether or not this is the last page of documents)
@@ -188,26 +188,26 @@ globs: **/*.ts,**/*.tsx,**/*.js,**/*.jsx
 ## Typescript guidelines
 - You can use the helper typescript type `Id` imported from './_generated/dataModel' to get the type of the id for a given table. For example if there is a table called 'users' you can use `Id<'users'>` to get the type of the id for that table.
 - If you need to define a `Record` make sure that you correctly provide the type of the key and value in the type. For example a validator `v.record(v.id('users'), v.string())` would have the type `Record<Id<'users'>, string>`. Below is an example of using `Record` with an `Id` type in a query:
-                    ```ts
-                    import { query } from "./_generated/server";
-                    import { Doc, Id } from "./_generated/dataModel";
+```ts
+import { query } from "./_generated/server";
+import { Doc, Id } from "./_generated/dataModel";
 
-                    export const exampleQuery = query({
-                        args: { userIds: v.array(v.id("users")) },
-                        returns: v.record(v.id("users"), v.string()),
-                        handler: async (ctx, args) => {
-                            const idToUsername: Record<Id<"users">, string> = {};
-                            for (const userId of args.userIds) {
-                                const user = await ctx.db.get(userId);
-                                if (user) {
-                                    users[user._id] = user.username;
-                                }
-                            }
+export const exampleQuery = query({
+    args: { userIds: v.array(v.id("users")) },
+    returns: v.record(v.id("users"), v.string()),
+    handler: async (ctx, args) => {
+        const idToUsername: Record<Id<"users">, string> = {};
+        for (const userId of args.userIds) {
+            const user = await ctx.db.get(userId);
+            if (user) {
+                idToUsername[user._id] = user.username;
+            }
+        }
 
-                            return idToUsername;
-                        },
-                    });
-                    ```
+        return idToUsername;
+    },
+});
+```
 - Be strict with types, particularly around id's of documents. For example, if a function takes in an id for a document in the 'users' table, take in `Id<'users'>` rather than `string`.
 - Always use `as const` for string literals in discriminated union types.
 - When using the `Array` type, make sure to always define your arrays as `const array: Array<T> = [...];`
@@ -243,46 +243,46 @@ const messages = await ctx.db
 - Always add `"use node";` to the top of files containing actions that use Node.js built-in modules.
 - Never use `ctx.db` inside of an action. Actions don't have access to the database.
 - Below is an example of the syntax for an action:
-                    ```ts
-                    import { action } from "./_generated/server";
+```ts
+import { action } from "./_generated/server";
 
-                    export const exampleAction = action({
-                        args: {},
-                        returns: v.null(),
-                        handler: async (ctx, args) => {
-                            console.log("This action does not return anything");
-                            return null;
-                        },
-                    });
-                    ```
+export const exampleAction = action({
+    args: {},
+    returns: v.null(),
+    handler: async (ctx, args) => {
+        console.log("This action does not return anything");
+        return null;
+    },
+});
+```
 
 ## Scheduling guidelines
 ### Cron guidelines
 - Only use the `crons.interval` or `crons.cron` methods to schedule cron jobs. Do NOT use the `crons.hourly`, `crons.daily`, or `crons.weekly` helpers.
 - Both cron methods take in a FunctionReference. Do NOT try to pass the function directly into one of these methods.
 - Define crons by declaring the top-level `crons` object, calling some methods on it, and then exporting it as default. For example,
-                            ```ts
-                            import { cronJobs } from "convex/server";
-                            import { internal } from "./_generated/api";
-                            import { internalAction } from "./_generated/server";
+```ts
+import { cronJobs } from "convex/server";
+import { internal } from "./_generated/api";
+import { internalAction } from "./_generated/server";
 
-                            const empty = internalAction({
-                              args: {},
-                              returns: v.null(),
-                              handler: async (ctx, args) => {
-                                console.log("empty");
-                              },
-                            });
+const empty = internalAction({
+  args: {},
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    console.log("empty");
+  },
+});
 
-                            const crons = cronJobs();
+const crons = cronJobs();
 
-                            // Run `internal.crons.empty` every two hours.
-                            crons.interval("delete inactive users", { hours: 2 }, internal.crons.empty, {});
+// Run `internal.crons.empty` every two hours.
+crons.interval("delete inactive users", { hours: 2 }, internal.crons.empty, {});
 
-                            export default crons;
-                            ```
+export default crons;
+```
 - You can register Convex functions within `crons.ts` just like any other file.
-- If a cron calls an internal function, always import the `internal` object from '_generated/api`, even if the internal function is registered in the same file.
+- If a cron calls an internal function, always import the `internal` object from '_generated/api', even if the internal function is registered in the same file.
 
 
 ## File storage guidelines
@@ -291,28 +291,28 @@ const messages = await ctx.db
 - Do NOT use the deprecated `ctx.storage.getMetadata` call for loading a file's metadata.
 
                     Instead, query the `_storage` system table. For example, you can use `ctx.db.system.get` to get an `Id<"_storage">`.
-                    ```
-                    import { query } from "./_generated/server";
-                    import { Id } from "./_generated/dataModel";
+```
+import { query } from "./_generated/server";
+import { Id } from "./_generated/dataModel";
 
-                    type FileMetadata = {
-                        _id: Id<"_storage">;
-                        _creationTime: number;
-                        contentType?: string;
-                        sha256: string;
-                        size: number;
-                    }
+type FileMetadata = {
+    _id: Id<"_storage">;
+    _creationTime: number;
+    contentType?: string;
+    sha256: string;
+    size: number;
+}
 
-                    export const exampleQuery = query({
-                        args: { fileId: v.id("_storage") },
-                        returns: v.null();
-                        handler: async (ctx, args) => {
-                            const metadata: FileMetadata | null = await ctx.db.system.get(args.fileId);
-                            console.log(metadata);
-                            return null;
-                        },
-                    });
-                    ```
+export const exampleQuery = query({
+    args: { fileId: v.id("_storage") },
+    returns: v.null(),
+    handler: async (ctx, args) => {
+        const metadata: FileMetadata | null = await ctx.db.system.get(args.fileId);
+        console.log(metadata);
+        return null;
+    },
+});
+```
 - Convex storage stores items as `Blob` objects. You must convert all items to/from a `Blob` when using Convex storage.
 
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bitravage/timeline",
   "private": false,
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "A reusable React timeline component with Notion integration",
   "main": "dist/index.umd.js",
   "module": "dist/index.es.js",

--- a/src/components/providers/ThemeProvider.tsx
+++ b/src/components/providers/ThemeProvider.tsx
@@ -47,13 +47,12 @@ const lightTheme: ThemeColors = {
   },
 };
 
-interface ThemeContextType {
-  colors: ThemeColors;
+interface ThemeContextType extends ThemeColors {
   mode: ThemeMode;
 }
 
 const ThemeContext = createContext<ThemeContextType>({
-  colors: darkTheme,
+  ...darkTheme,
   mode: 'dark',
 });
 
@@ -84,7 +83,7 @@ export const ThemeProvider: React.FC<ThemeProviderProps> = ({
   }, [colors]);
 
   return (
-    <ThemeContext.Provider value={{ colors, mode: theme }}>
+    <ThemeContext.Provider value={{ ...colors, mode: theme }}>
       {children}
     </ThemeContext.Provider>
   );

--- a/src/components/providers/TimelineStateProvider.tsx
+++ b/src/components/providers/TimelineStateProvider.tsx
@@ -1,6 +1,6 @@
 import React, { createContext, useContext, useState, ReactNode, useMemo, useEffect } from 'react';
 import { useAction } from "convex/react";
-import { api } from "../../../convex-api";
+import { api } from "../../../convex/_generated/api";
 import { ErrorBoundary } from '../status/ErrorBoundary';
 import { ErrorFallback } from '../status/ErrorFallback';
 
@@ -22,7 +22,7 @@ interface TimelineStateContextType {
   completePhase: (phaseId: string) => void;
   completeTask: (taskId: string) => void;
   phases: PhaseGroup;
-  syncStatus: { status: string; lastSyncTime: number | null; recordCount: number; error?: string };
+  syncStatus: { status: string; lastSyncTime: number | null; recordCount: number; error?: string | undefined };
   isLoading: boolean;
   triggerSync: () => void;
   lastFetch: Date | null;
@@ -46,7 +46,7 @@ export const TimelineStateProvider: React.FC<TimelineStateProviderProps> = ({ ch
   const [allTasks, setAllTasks] = useState<any[] | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [lastFetch, setLastFetch] = useState<Date | null>(null);
-  const [syncStatus, setSyncStatus] = useState({ status: 'direct_api', lastSyncTime: null, recordCount: 0, error: undefined });
+  const [syncStatus, setSyncStatus] = useState<{ status: string; lastSyncTime: number | null; recordCount: number; error?: string | undefined }>({ status: 'direct_api', lastSyncTime: null, recordCount: 0, error: undefined });
   
   const getProjectTimelineDirectAction = useAction(api.directNotionApi.getProjectTimelineDirect);
 

--- a/src/components/status/TaskStatus.tsx
+++ b/src/components/status/TaskStatus.tsx
@@ -7,13 +7,15 @@ interface TaskStatusProps {
   hasWarning?: boolean;
   hasError?: boolean;
   isLoading?: boolean;
+  isActive?: boolean;
 }
 
 export const TaskStatus: React.FC<TaskStatusProps> = ({ 
   complete, 
   hasWarning = false, 
   hasError = false,
-  isLoading = false
+  isLoading = false,
+  isActive = false
 }) => {
   try {
     const theme = useTheme();


### PR DESCRIPTION
## 🎯 Summary

Fixed the theme prop functionality in the Timeline component. The `<Timeline theme='dark' />` and `<Timeline theme='light' />` props now work correctly.

## 🐛 Root Cause

The ThemeProvider was nesting theme properties under `theme.colors.*` but components expected them directly as `theme.text`, `theme.accent`, etc. This caused TypeScript errors and prevented theme switching.

## ✅ What's Fixed

- **Theme Context Structure**: Flattened ThemeContextType to extend ThemeColors directly
- **Component Access**: All 25+ components can now access `theme.text`, `theme.accent`, etc. directly  
- **TypeScript Errors**: Resolved all "Property 'accent' does not exist" errors
- **Theme Switching**: Both light and dark themes now apply correctly
- **API Imports**: Updated to use generated Convex API
- **Missing Props**: Added `isActive` prop to TaskStatus component

## 🧪 Test Results

- ✅ `npm run lint` passes with no TypeScript errors
- ✅ `npm run build:lib` succeeds
- ✅ `<Timeline theme='dark' />` applies dark theme correctly
- ✅ `<Timeline theme='light' />` applies light theme correctly
- ✅ Published as @bitravage/timeline@1.0.8

## 📦 Changes Made

### Core Fixes
- `src/components/providers/ThemeProvider.tsx`: Flattened theme context interface
- `src/components/providers/TimelineStateProvider.tsx`: Fixed API imports and type annotations
- `src/components/status/TaskStatus.tsx`: Added missing `isActive` prop
- `package.json`: Bumped version to 1.0.8

### Technical Details
```typescript
// Before: Components couldn't access theme properties
interface ThemeContextType {
  colors: ThemeColors;
  mode: ThemeMode;
}

// After: Components can access theme properties directly
interface ThemeContextType extends ThemeColors {
  mode: ThemeMode;
}
```

## 🚀 NPM Release

Published **@bitravage/timeline@1.0.8** to NPM registry:
- Package size: 91.0 kB
- ES modules: 41.22 kB gzipped
- All automatic CSS injection features preserved

🤖 Generated with [Claude Code](https://claude.ai/code)